### PR TITLE
Capture and mux packets on all interfaces.

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/m-lab/go/anonymize"
 
 	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 
 	"github.com/m-lab/go/flagx"
@@ -31,7 +30,7 @@ var (
 	flowTimeout     = flag.Duration("flowtimeout", 30*time.Second, "Once there have been no packets for a flow for at least flowtimeout, the flow can be assumed to be closed.")
 	maxHeaderSize   = flag.Int("maxheadersize", 256, "The maximum size of packet headers allowed. A lower value allows the pcap process to be less wasteful but risks more esoteric IPv6 headers (which can theoretically be up to the full size of the packet but in practice seem to be under 128) getting truncated.")
 
-	netInterface flagx.StringArray
+	interfaces flagx.StringArray
 
 	// Context and injected variables to allow smoke testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -39,12 +38,22 @@ var (
 )
 
 func init() {
-	flag.Var(&netInterface, "interface", "The interface on which to sniff traffic. May be repeated. If unset, will sniff on all interfaces.")
+	flag.Var(&interfaces, "interface", "The interface on which to capture traffic. May be repeated. If unset, will capture on all available interfaces.")
 }
 
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
+
+	// Special case for argument "-interface": if no interface was specified,
+	// then all of them were implicitly specified.
+	if len(interfaces) == 0 {
+		ifaces, err := net.Interfaces()
+		rtx.Must(err, "Could not list interfaces")
+		for _, iface := range ifaces {
+			interfaces = append(interfaces, iface.Name)
+		}
+	}
 
 	defer mainCancel()
 	psrv := prometheusx.MustServeMetrics()
@@ -52,9 +61,10 @@ func main() {
 
 	rtx.Must(os.Chdir(*dir), "Could not cd to directory %q", *dir)
 
-	// A waitgroup to make sure main() doesn't exit before all its components
+	// A waitgroup to make sure main() doesn't return before all its components
 	// get cleaned up.
 	cleanupWG := sync.WaitGroup{}
+	defer cleanupWG.Wait()
 
 	// Get ready to save the incoming packets to files.
 	tcpdm := demuxer.NewTCP(anonymize.New(anonymize.IPAnonymizationFlag), *dir, *captureDuration)
@@ -67,42 +77,13 @@ func main() {
 		cleanupWG.Done()
 	}()
 
-	// Special case: if no interface is specified, pretend all of them were specified.
-	if len(netInterface) == 0 {
-		interfaces, err := net.Interfaces()
-		rtx.Must(err, "Could not list interfaces")
-		for _, iface := range interfaces {
-			netInterface = append(netInterface, iface.Name)
-		}
-	}
-
-	// Capture packets on every interface.
-	packetCaptures := make([]<-chan gopacket.Packet, 0)
-	for _, iface := range netInterface {
-		// Open a packet capture
-		handle, err := pcapOpenLive(iface, int32(*maxHeaderSize), true, pcap.BlockForever)
-		rtx.Must(err, "Could not create libpcap client for %q", iface)
-		rtx.Must(handle.SetBPFFilter("tcp"), "Could not set up BPF filter for TCP")
-
-		// Stop packet capture when the context is canceled.
-		cleanupWG.Add(1)
-		go func(h *pcap.Handle) {
-			<-mainCtx.Done()
-			h.Close()
-			cleanupWG.Done()
-		}(handle)
-
-		// Save the packet capture channel.
-		packetCaptures = append(packetCaptures, gopacket.NewPacketSource(handle, layers.LinkTypeEthernet).Packets())
-	}
-
 	// A channel with a buffer to prevent tight coupling of captures.
 	packets := make(chan gopacket.Packet, 1000)
 
-	// Cause all captures to go to the same channel.
+	// Capture packets on every interface.
 	cleanupWG.Add(1)
 	go func() {
-		muxer.MuxPackets(mainCtx, packetCaptures, packets)
+		muxer.MustCaptureTCPOnInterfaces(mainCtx, interfaces, packets, pcapOpenLive, int32(*maxHeaderSize))
 		cleanupWG.Done()
 	}()
 
@@ -112,7 +93,4 @@ func main() {
 
 	// Capture packets forever, or until mainCtx is cancelled.
 	tcpdm.CapturePackets(mainCtx, packets, flowTimeoutTicker.C)
-
-	// Wait until all cleanup routines have terminated.
-	cleanupWG.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,8 @@ func main() {
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
 
 	// Special case for argument "-interface": if no interface was specified,
-	// then all of them were implicitly specified.
+	// then all of them were implicitly specified. If new interfaces are created
+	// after capture is started, traffic on those interfaqces will be ignored.
 	if len(interfaces) == 0 {
 		ifaces, err := net.Interfaces()
 		rtx.Must(err, "Could not list interfaces")

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// Special case for argument "-interface": if no interface was specified,
 	// then all of them were implicitly specified. If new interfaces are created
-	// after capture is started, traffic on those interfaqces will be ignored.
+	// after capture is started, traffic on those interfaces will be ignored.
 	if len(interfaces) == 0 {
 		ifaces, err := net.Interfaces()
 		rtx.Must(err, "Could not list interfaces")
@@ -79,7 +79,7 @@ func main() {
 		cleanupWG.Done()
 	}()
 
-	// A channel with a buffer to prevent tight coupling of captures.
+	// A channel with a buffer to prevent tight coupling of captures with the demuxer.TCP goroutine's read loop.
 	packets := make(chan gopacket.Packet, 1000)
 
 	// Capture packets on every interface.

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net"
 	"os"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/go/warnonerror"
 	"github.com/m-lab/packet-headers/demuxer"
+	"github.com/m-lab/packet-headers/muxer"
 	"github.com/m-lab/packet-headers/tcpinfohandler"
 	"github.com/m-lab/tcp-info/eventsocket"
 )
@@ -28,12 +30,17 @@ var (
 	captureDuration = flag.Duration("captureduration", 30*time.Second, "Only save the first captureduration of each flow, to prevent long-lived flows from spamming the hard drive.")
 	flowTimeout     = flag.Duration("flowtimeout", 30*time.Second, "Once there have been no packets for a flow for at least flowtimeout, the flow can be assumed to be closed.")
 	maxHeaderSize   = flag.Int("maxheadersize", 256, "The maximum size of packet headers allowed. A lower value allows the pcap process to be less wasteful but risks more esoteric IPv6 headers (which can theoretically be up to the full size of the packet but in practice seem to be under 128) getting truncated.")
-	netInterface    = flag.String("interface", "eth0", "The interface on which to capture packets.")
+
+	netInterface flagx.StringArray
 
 	// Context and injected variables to allow smoke testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 	pcapOpenLive        = pcap.OpenLive
 )
+
+func init() {
+	flag.Var(&netInterface, "interface", "The interface on which to sniff traffic. May be repeated. If unset, will sniff on all interfaces.")
+}
 
 func main() {
 	flag.Parse()
@@ -60,27 +67,51 @@ func main() {
 		cleanupWG.Done()
 	}()
 
-	// Open a packet capture
-	handle, err := pcapOpenLive(*netInterface, int32(*maxHeaderSize), true, pcap.BlockForever)
-	rtx.Must(err, "Could not create libpcap client")
-	rtx.Must(handle.SetBPFFilter("tcp"), "Could not set up BPF filter for TCP")
-	// Stop packet capture when the context is canceled.
+	// Special case: if no interface is specified, pretend all of them were specified.
+	if len(netInterface) == 0 {
+		interfaces, err := net.Interfaces()
+		rtx.Must(err, "Could not list interfaces")
+		for _, iface := range interfaces {
+			netInterface = append(netInterface, iface.Name)
+		}
+	}
+
+	// Capture packets on every interface.
+	packetCaptures := make([]<-chan gopacket.Packet, 0)
+	for _, iface := range netInterface {
+		// Open a packet capture
+		handle, err := pcapOpenLive(iface, int32(*maxHeaderSize), true, pcap.BlockForever)
+		rtx.Must(err, "Could not create libpcap client for %q", iface)
+		rtx.Must(handle.SetBPFFilter("tcp"), "Could not set up BPF filter for TCP")
+
+		// Stop packet capture when the context is canceled.
+		cleanupWG.Add(1)
+		go func(h *pcap.Handle) {
+			<-mainCtx.Done()
+			h.Close()
+			cleanupWG.Done()
+		}(handle)
+
+		// Save the packet capture channel.
+		packetCaptures = append(packetCaptures, gopacket.NewPacketSource(handle, layers.LinkTypeEthernet).Packets())
+	}
+
+	// A channel with a buffer to prevent tight coupling of captures.
+	packets := make(chan gopacket.Packet, 1000)
+
+	// Cause all captures to go to the same channel.
 	cleanupWG.Add(1)
 	go func() {
-		<-mainCtx.Done()
-		handle.Close()
+		muxer.MuxPackets(mainCtx, packetCaptures, packets)
 		cleanupWG.Done()
 	}()
-
-	// Set up the packet capture.
-	packetSource := gopacket.NewPacketSource(handle, layers.LinkTypeEthernet)
 
 	// Set up the timer for flow timeouts.
 	flowTimeoutTicker := time.NewTicker(*flowTimeout)
 	defer flowTimeoutTicker.Stop()
 
 	// Capture packets forever, or until mainCtx is cancelled.
-	tcpdm.CapturePackets(mainCtx, packetSource.Packets(), flowTimeoutTicker.C)
+	tcpdm.CapturePackets(mainCtx, packets, flowTimeoutTicker.C)
 
 	// Wait until all cleanup routines have terminated.
 	cleanupWG.Wait()

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func init() {
 }
 
 func main() {
+	defer mainCancel()
+
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
 
@@ -55,7 +57,6 @@ func main() {
 		}
 	}
 
-	defer mainCancel()
 	psrv := prometheusx.MustServeMetrics()
 	defer warnonerror.Close(psrv, "Could not stop metric server")
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -86,5 +86,12 @@ var (
 		[]string{"reason"},
 	)
 
+	InterfacesBeingCaptured = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "pcap_muxer_interfaces_with_captures",
+			Help: "How many interfaces currently have a packet capture running on them, according to the muxer.",
+		},
+	)
+
 // TODO(https://github.com/m-lab/packet-headers/issues/5) Create some histograms for SLIs
 )

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -1,10 +1,17 @@
+// Package muxer helps solve the problem that captures take place only on a
+// per-interface basis, but tcp-info collects flow information with no reference
+// to the underlying interface.
 package muxer
 
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"github.com/m-lab/go/rtx"
 )
 
 func forwardPackets(ctx context.Context, in <-chan gopacket.Packet, out chan<- gopacket.Packet, wg *sync.WaitGroup) {
@@ -23,8 +30,8 @@ func forwardPackets(ctx context.Context, in <-chan gopacket.Packet, out chan<- g
 	}
 }
 
-// MuxPackets causes every packet on every input channel to be sent to the output channel.
-func MuxPackets(ctx context.Context, in []<-chan gopacket.Packet, out chan<- gopacket.Packet) {
+// muxPackets causes each packet on every input channel to be sent to the output channel.
+func muxPackets(ctx context.Context, in []<-chan gopacket.Packet, out chan<- gopacket.Packet) {
 	wg := sync.WaitGroup{}
 	for _, inC := range in {
 		wg.Add(1)
@@ -33,4 +40,33 @@ func MuxPackets(ctx context.Context, in []<-chan gopacket.Packet, out chan<- gop
 
 	wg.Wait()
 	close(out)
+}
+
+// PcapHandleOpener is a type to allow injection of fake packet captures to aid
+// in testing. It is exactly the type of pcap.OpenLive, and in production code
+// every variable of this type should be set to pcap.OpenLive.
+type PcapHandleOpener func(device string, snaplen int32, promisc bool, timeout time.Duration) (handle *pcap.Handle, _ error)
+
+// MustCaptureTCPOnInterfaces fires off a packet capture on every one of the
+// passed-in list of interfaces, and then muxes the resulting packet streams to
+// all be sent to the passed-in packets channel.
+func MustCaptureTCPOnInterfaces(ctx context.Context, interfaces []string, packets chan<- gopacket.Packet, opener PcapHandleOpener, maxHeaderSize int32) {
+	// Capture packets on every interface.
+	packetCaptures := make([]<-chan gopacket.Packet, 0)
+	for _, iface := range interfaces {
+		// Open a packet capture
+		handle, err := opener(iface, maxHeaderSize, true, pcap.BlockForever)
+		rtx.Must(err, "Could not create libpcap client for %q", iface)
+		rtx.Must(handle.SetBPFFilter("tcp"), "Could not set up BPF filter for TCP")
+
+		// Stop packet capture when this function exits.
+		defer handle.Close()
+
+		// Save the packet capture channel.
+		packetCaptures = append(packetCaptures, gopacket.NewPacketSource(handle, layers.LinkTypeEthernet).Packets())
+	}
+
+	// multiplex packets until all packet sources are exhausted or the context
+	// is cancelled.
+	muxPackets(ctx, packetCaptures, packets)
 }

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -1,0 +1,36 @@
+package muxer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/gopacket"
+)
+
+func forwardPackets(ctx context.Context, in <-chan gopacket.Packet, out chan<- gopacket.Packet, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for {
+		select {
+		case p, ok := <-in:
+			if !ok {
+				return
+			}
+			out <- p
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// MuxPackets causes every packet on every input channel to be sent to the output channel.
+func MuxPackets(ctx context.Context, in []<-chan gopacket.Packet, out chan<- gopacket.Packet) {
+	wg := sync.WaitGroup{}
+	for _, inC := range in {
+		wg.Add(1)
+		go forwardPackets(ctx, inC, out, &wg)
+	}
+
+	wg.Wait()
+	close(out)
+}

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -12,10 +12,13 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/packet-headers/metrics"
 )
 
 func forwardPackets(ctx context.Context, in <-chan gopacket.Packet, out chan<- gopacket.Packet, wg *sync.WaitGroup) {
 	defer wg.Done()
+	metrics.InterfacesBeingCaptured.Inc()
+	defer metrics.InterfacesBeingCaptured.Dec()
 
 	for {
 		select {

--- a/muxer/interfaces_test.go
+++ b/muxer/interfaces_test.go
@@ -1,13 +1,108 @@
 package muxer
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/pcap"
+	"github.com/m-lab/go/rtx"
 )
 
-func TestMuxPackets(t *testing.T) {
+func channelFromFile(fname string) <-chan gopacket.Packet {
+	// Get packets from a wireshark-produced pcap file.
+	handle, err := pcap.OpenOffline(fname)
+	rtx.Must(err, "Could not open golden pcap file %s", fname)
+	ps := gopacket.NewPacketSource(handle, handle.LinkType())
+	return ps.Packets()
+}
+
+func TestMuxPacketsUntilSourceExhaustion(t *testing.T) {
 	// Open our two testfiles
-	// Mux the packets from each.
-	// Close each channel.
-	// Verify that all input channels closing causes the output channel to close.
+	ins := []<-chan gopacket.Packet{
+		channelFromFile("../testdata/v4.pcap"),
+		channelFromFile("../testdata/v6.pcap"),
+	}
+	out := make(chan gopacket.Packet)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		// Mux the packets from each.
+		muxPackets(context.Background(), ins, out)
+		wg.Done()
+	}()
+	// The only way that this will close is if we exhaust all the input channels
+	// and they each close. So let's do that.
+	pcount := 0
+	for range out {
+		pcount++
+	}
+	wg.Wait()
 	// Verify that the combined flow contains the right number of packets.
+	if pcount != 20 {
+		t.Errorf("pcount should be 20, not %d", pcount)
+	}
+}
+
+func TestMuxPacketsUntilContextCancellation(t *testing.T) {
+	ins := []<-chan gopacket.Packet{
+		make(chan gopacket.Packet),
+		make(chan gopacket.Packet),
+	}
+	out := make(chan gopacket.Packet)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Mux the packets from each.
+		muxPackets(ctx, ins, out)
+		wg.Done()
+	}()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	// The only way that this will close is if we exhaust all the input channels
+	// and they each close. So let's do that.
+	pcount := 0
+	for range out {
+		pcount++
+	}
+	wg.Wait()
+	// Verify that the combined flow contains the right number of packets.
+	if pcount != 0 {
+		t.Errorf("pcount should be 0, not %d", pcount)
+	}
+
+}
+
+func fakePcapOpenLive(filename string, _ int32, _ bool, _ time.Duration) (*pcap.Handle, error) {
+	return pcap.OpenOffline(filename)
+}
+
+func TestMustCaptureOnInterfaces(t *testing.T) {
+	wg := sync.WaitGroup{}
+	packets := make(chan gopacket.Packet)
+	wg.Add(1)
+	go func() {
+		MustCaptureTCPOnInterfaces(
+			context.Background(),
+			[]string{"../testdata/v4.pcap", "../testdata/v6.pcap"},
+			packets,
+			fakePcapOpenLive,
+			0,
+		)
+		wg.Done()
+	}()
+
+	count := 0
+	for range packets {
+		count++
+	}
+	wg.Wait()
+	if count != 20 {
+		t.Errorf("Was supposed to see 20 packets, but instead saw %d", count)
+	}
 }

--- a/muxer/interfaces_test.go
+++ b/muxer/interfaces_test.go
@@ -64,14 +64,15 @@ func TestMuxPacketsUntilContextCancellation(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		cancel()
 	}()
-	// The only way that this will close is if we exhaust all the input channels
-	// and they each close. So let's do that.
+	// The input channels will never close, so only context cancellation will work.
 	pcount := 0
 	for range out {
 		pcount++
 	}
 	wg.Wait()
-	// Verify that the combined flow contains the right number of packets.
+	// If we got to here, then muxPackets terminated!  Hooray!
+
+	// Verify that the combined flow contained no packets.
 	if pcount != 0 {
 		t.Errorf("pcount should be 0, not %d", pcount)
 	}

--- a/muxer/interfaces_test.go
+++ b/muxer/interfaces_test.go
@@ -1,0 +1,13 @@
+package muxer
+
+import (
+	"testing"
+)
+
+func TestMuxPackets(t *testing.T) {
+	// Open our two testfiles
+	// Mux the packets from each.
+	// Close each channel.
+	// Verify that all input channels closing causes the output channel to close.
+	// Verify that the combined flow contains the right number of packets.
+}


### PR DESCRIPTION
Captures packets on all interfaces.

Fixes #8
Part of m-lab/dev-tracker#442 and m-lab/dev-tracker#443

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/12)
<!-- Reviewable:end -->
