### PR TITLE
Add context to Open & Close methods

### DIFF
--- a/tcpinfohandler/handler.go
+++ b/tcpinfohandler/handler.go
@@ -27,7 +27,7 @@ type handler struct {
 }
 
 // Open processes an Open message for a new flow, sending its UUID to the demuxer.
-func (h *handler) Open(timestamp time.Time, uuid string, id *inetdiag.SockID) {
+func (h *handler) Open(ctx context.Context, timestamp time.Time, uuid string, id *inetdiag.SockID) {
 	if id == nil {
 		metrics.BadEventsFromTCPInfo.WithLabelValues("nilid").Inc()
 		return
@@ -48,7 +48,7 @@ func (h *handler) Open(timestamp time.Time, uuid string, id *inetdiag.SockID) {
 }
 
 // Close does nothing.  Timeouts are the authoritative closing mechanism.
-func (h *handler) Close(timestamp time.Time, uuid string) {
+func (h *handler) Close(ctx context.Context, timestamp time.Time, uuid string) {
 }
 
 // New makes a new eventsocket.Handler that informs the demuxer of new flow

--- a/tcpinfohandler/handler_test.go
+++ b/tcpinfohandler/handler_test.go
@@ -16,8 +16,8 @@ func TestHandlerOpen(t *testing.T) {
 	c := make(chan demuxer.UUIDEvent, 1)
 	h := New(ctx, c)
 
-	h.Open(time.Now(), "nildata", nil)               // No crash == success
-	h.Open(time.Now(), "badips", &inetdiag.SockID{}) // No crash == success
+	h.Open(ctx, time.Now(), "nildata", nil)               // No crash == success
+	h.Open(ctx, time.Now(), "badips", &inetdiag.SockID{}) // No crash == success
 
 	// Channel should be empty after the bad messages.
 	select {
@@ -40,7 +40,7 @@ func TestHandlerOpen(t *testing.T) {
 		DPort: dPort,
 	}
 
-	h.Open(timestamp, uuid, sockid)
+	h.Open(ctx, timestamp, uuid, sockid)
 	// Read the event from the channel
 	e := <-c
 	if e.Timestamp != timestamp {
@@ -51,5 +51,5 @@ func TestHandlerOpen(t *testing.T) {
 	}
 
 	// Make sure that Close won't crash. It should do nothing.
-	h.Close(timestamp, uuid) // no crash == success
+	h.Close(ctx, timestamp, uuid) // no crash == success
 }


### PR DESCRIPTION
After https://github.com/m-lab/tcp-info/pull/111 this change updates the handler implementation to satisfiy the new `eventsocket.Handler` interface by adding a `context.Context` parameter to the Open and Close methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/22)
<!-- Reviewable:end -->
