### PR TITLE
Save to .pcap.gz instead of .pcap

### DIFF
--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -165,14 +166,15 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	var err1, err2 error
 	err1 = errors.New("start out with an error")
 	for err1 != nil || err2 != nil {
-		_, err1 = os.Stat(dir + "/2013/10/31/flow1.pcap")
-		_, err2 = os.Stat(dir + "/2013/10/30/flow2.pcap")
+		_, err1 = os.Stat(dir + "/2013/10/31/flow1.pcap.gz")
+		_, err2 = os.Stat(dir + "/2013/10/30/flow2.pcap.gz")
 		time.Sleep(100 * time.Millisecond)
 	}
 
 	// Verify the files' contents.
+	rtx.Must(exec.Command("gunzip", dir+"/2013/10/31/flow1.pcap.gz").Run(), "Could not unzip flow1")
 	handle, err = pcap.OpenOffline(dir + "/2013/10/31/flow1.pcap")
-	rtx.Must(err, "Could not open golden pcap file")
+	rtx.Must(err, "Could not open golden pcap file: flow1.pcap")
 	ps = gopacket.NewPacketSource(handle, handle.LinkType())
 	v4 := make([]gopacket.Packet, 0)
 	for p := range ps.Packets() {
@@ -182,8 +184,9 @@ func TestTCPWithRealPcaps(t *testing.T) {
 		t.Errorf("%+v should have length 12 not %d", v4, len(v4))
 	}
 
+	rtx.Must(exec.Command("gunzip", dir+"/2013/10/30/flow2.pcap.gz").Run(), "Could not unzip flow2")
 	handle, err = pcap.OpenOffline(dir + "/2013/10/30/flow2.pcap")
-	rtx.Must(err, "Could not open golden pcap file")
+	rtx.Must(err, "Could not open golden pcap file: flow2.pcap")
 	ps = gopacket.NewPacketSource(handle, handle.LinkType())
 	v6 := make([]gopacket.Packet, 0)
 	for p := range ps.Packets() {

--- a/saver/tcp_test.go
+++ b/saver/tcp_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/exec"
 	"reflect"
 	"testing"
 	"time"
@@ -16,6 +17,10 @@ import (
 	"github.com/m-lab/go/anonymize"
 	"github.com/m-lab/go/rtx"
 )
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func TestMinInt(t *testing.T) {
 	for _, c := range []struct{ x, y, want int }{
@@ -276,7 +281,9 @@ func TestSaverWithRealv4Data(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	log.Println("reading data from", dir+"/2000/01/02/testUUID.pcap")
+	log.Println("reading data from", dir+"/2000/01/02/testUUID.pcap.gz")
+	rtx.Must(exec.Command("gunzip", dir+"/2000/01/02/testUUID.pcap.gz").Run(), "Could not unzip")
+
 	handle, err := pcap.OpenOffline(dir + "/2000/01/02/testUUID.pcap")
 	rtx.Must(err, "Could not open written pcap file")
 	ps := gopacket.NewPacketSource(handle, handle.LinkType())
@@ -352,6 +359,7 @@ func TestSaverWithRealv6Data(t *testing.T) {
 	}
 
 	log.Println("reading data from", dir+"/2000/01/02/testUUID.pcap")
+	rtx.Must(exec.Command("gunzip", dir+"/2000/01/02/testUUID.pcap.gz").Run(), "Could not unzip")
 	handle, err := pcap.OpenOffline(dir + "/2000/01/02/testUUID.pcap")
 	rtx.Must(err, "Could not open written pcap file")
 	ps := gopacket.NewPacketSource(handle, handle.LinkType())


### PR DESCRIPTION
Trades CPU for RAM and disk IO.  Both RAM and (especially) disk IO are scarce resources on server machines, so this is probably a good trade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/24)
<!-- Reviewable:end -->
