### PR TITLE
Default return after uuid miss, and reduce chan buffer

### DIFF
--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -202,7 +202,7 @@ func (t *TCP) savePackets(ctx context.Context, duration time.Duration) {
 			t.error("uuidchan")
 			return
 		}
-	case <-ctx.Done():
+	default:
 		log.Println("Context cancelled, PCAP capture cancelled with no UUID")
 		t.error("uuid")
 		return
@@ -288,7 +288,7 @@ func newTCP(dir string, anon anonymize.IPAnonymizer) *TCP {
 	//
 	// If synchronization between UUID creation and packet collection is off by
 	// more than a second, things are messed up.
-	pchan := make(chan gopacket.Packet, 833333)
+	pchan := make(chan gopacket.Packet, 8192)
 
 	// There should only ever be (at most) one write to the UUIDchan, so a
 	// capacity of 1 means that the write should never block.


### PR DESCRIPTION
Addresses https://github.com/m-lab/packet-headers/issues/20

This change will return immediately if there is no UUID to identify the flow, causing all buffered and new packets to be discarded immediately. As well, this change reduces the static packet channel buffer from 833,333 to 8192. During load testing with an adhoc metric, I never observed the chan utilization above 8k and we have a metric counting "missed" packets so if this is a problem, we'll know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/25)
<!-- Reviewable:end -->
