### PR TITLE
Abandon savers without UUIDs after 5 seconds

### DIFF
--- a/demuxer/tcp.go
+++ b/demuxer/tcp.go
@@ -36,9 +36,10 @@ type TCP struct {
 	oldFlows     map[FlowKey]*saver.TCP
 
 	// Variables required for the construction of new Savers
-	maxDuration time.Duration
-	anon        anonymize.IPAnonymizer
-	dataDir     string
+	maxDuration      time.Duration
+	uuidWaitDuration time.Duration
+	anon             anonymize.IPAnonymizer
+	dataDir          string
 }
 
 // GetSaver returns a saver with channels for packets and a uuid.
@@ -52,7 +53,7 @@ func (d *TCP) getSaver(ctx context.Context, flow FlowKey) *saver.TCP {
 		if ok {
 			delete(d.oldFlows, flow)
 		} else {
-			t = saver.StartNew(ctx, d.anon, d.dataDir, d.maxDuration)
+			t = saver.StartNew(ctx, d.anon, d.dataDir, d.uuidWaitDuration, d.maxDuration)
 		}
 		d.currentFlows[flow] = t
 	}
@@ -140,7 +141,7 @@ func (d *TCP) CapturePackets(ctx context.Context, packets <-chan gopacket.Packet
 
 // NewTCP creates a demuxer.TCP, which is the system which chooses which channel
 // to send TCP/IP packets for subsequent saving to a file.
-func NewTCP(anon anonymize.IPAnonymizer, dataDir string, maxFlowDuration time.Duration) *TCP {
+func NewTCP(anon anonymize.IPAnonymizer, dataDir string, uuidWaitDuration, maxFlowDuration time.Duration) *TCP {
 	uuidc := make(chan UUIDEvent, 100)
 	return &TCP{
 		UUIDChan:     uuidc,
@@ -149,8 +150,9 @@ func NewTCP(anon anonymize.IPAnonymizer, dataDir string, maxFlowDuration time.Du
 		currentFlows: make(map[FlowKey]*saver.TCP),
 		oldFlows:     make(map[FlowKey]*saver.TCP),
 
-		anon:        anon,
-		dataDir:     dataDir,
-		maxDuration: maxFlowDuration,
+		anon:             anon,
+		dataDir:          dataDir,
+		maxDuration:      maxFlowDuration,
+		uuidWaitDuration: uuidWaitDuration,
 	}
 }

--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -38,7 +38,7 @@ func TestTCPDryRun(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second)
 
 	// While we have a demuxer created, make sure that the processing path for
 	// packets does not crash when given a nil packet.
@@ -60,7 +60,7 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -225,7 +225,7 @@ func TestUUIDWontBlock(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 30*time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/m-lab/go/warnonerror"
 	"github.com/m-lab/packet-headers/demuxer"
 	"github.com/m-lab/packet-headers/muxer"
+	"github.com/m-lab/packet-headers/saver"
 	"github.com/m-lab/packet-headers/tcpinfohandler"
 	"github.com/m-lab/tcp-info/eventsocket"
 )
@@ -67,6 +68,10 @@ func main() {
 
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
+
+	if saver.UUIDDelay > *captureDuration {
+		rtx.Must(fmt.Errorf("Capture delay must be greater than saver.UUIDDelay: %s", saver.UUIDDelay), "")
+	}
 
 	// Special case for argument "-interface": if no specific interface was
 	// specified, then "all of them" was implicitly specified. If new interfaces

--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -185,7 +185,7 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	w.WriteFileHeader(uint32(headerLen), layers.LinkTypeEthernet)
 	t.savePacket(w, p, headerLen)
 
-	// Read packets for the first UUIDDelay seconds.
+	// Read packets for the first uuid wait duration seconds.
 	for {
 		p, ok := t.readPacket(uuidCtx)
 		if !ok {

--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -210,11 +210,7 @@ func (t *TCP) savePackets(ctx context.Context, duration time.Duration) {
 			return
 		}
 	default:
-<<<<<<< HEAD
-		log.Println("Context cancelled, PCAP capture cancelled with no UUID")
-=======
 		log.Println("UUID did not arraive; PCAP capture cancelled with no UUID")
->>>>>>> 5-25 split around uuid
 		t.error("uuid")
 		return
 	}
@@ -314,13 +310,9 @@ func newTCP(dir string, anon anonymize.IPAnonymizer) *TCP {
 	// 125KB for channel capacity and 12.5MB of actual packet data.
 	//
 	// If synchronization between UUID creation and packet collection is off by
-<<<<<<< HEAD
 	// more than 10 ms, packets may be missed. However, under load testing we
 	// never observed capacity greater than 8K. Conditions that are worse than
 	// load testing will have bigger problems.
-=======
-	// more than a second, things are messed up.
->>>>>>> 5-25 split around uuid
 	pchan := make(chan gopacket.Packet, 8192)
 
 	// There should only ever be (at most) one write to the UUIDchan, so a

--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -211,7 +211,7 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	}
 	// uuidEvent is now set to a good value.
 
-	// Continue reading packets until duration seconds.
+	// Continue reading packets until duration has elapsed.
 	for {
 		p, ok := t.readPacket(derivedCtx)
 		if !ok {

--- a/saver/tcp_test.go
+++ b/saver/tcp_test.go
@@ -103,7 +103,7 @@ func TestSaverDryRun(t *testing.T) {
 		cancel()
 	}()
 
-	s.start(ctx, 10*time.Second) // Give the disk IO 10 seconds to happen.
+	s.start(ctx, 5*time.Second, 10*time.Second) // Give the disk IO 10 seconds to happen.
 	expected := statusTracker{
 		status: "stopped",
 		past:   []string{"notstarted", "readingpackets", "nopacketserror", "discardingpackets"},
@@ -138,17 +138,16 @@ func TestSaverWithUUID(t *testing.T) {
 	}
 	// Send a UUID.
 	s.UUIDchan <- UUIDEvent{"testUUID", time.Now()}
-	UUIDDelay = 100 * time.Millisecond
 
 	// Run saver in background.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	go func() {
 		defer cancel()
-		s.start(ctx, 2*time.Second)
+		s.start(ctx, 100*time.Millisecond, 2*time.Second)
 	}()
 
-	// Wait for 2x UUIDDelay to move to the second read/save loop.
-	time.Sleep(2 * UUIDDelay)
+	// Wait for 2x UUID wait duration to move to the second read/save loop.
+	time.Sleep(200 * time.Millisecond)
 	for i := len(packets) / 2; i < len(packets); i++ {
 		s.Pchan <- packets[i]
 	}
@@ -187,7 +186,7 @@ func TestSaverNoUUID(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	s.start(ctx, 10*time.Second)
+	s.start(ctx, 5*time.Second, 10*time.Second)
 	expected := statusTracker{
 		status: "stopped",
 		past:   []string{"notstarted", "readingpackets", "uuidwait", "uuiderror", "discardingpackets"},
@@ -218,7 +217,7 @@ func TestSaverNoUUIDClosedUUIDChan(t *testing.T) {
 	close(s.Pchan)
 	close(s.UUIDchan)
 
-	s.start(context.Background(), 10*time.Second)
+	s.start(context.Background(), 5*time.Second, 10*time.Second)
 	expected := statusTracker{
 		status: "stopped",
 		past:   []string{"notstarted", "readingpackets", "uuidwait", "uuidchanerror", "discardingpackets"},
@@ -251,7 +250,7 @@ func TestSaverCantMkdir(t *testing.T) {
 	}
 	close(s.Pchan)
 
-	s.start(context.Background(), 10*time.Second)
+	s.start(context.Background(), 5*time.Second, 10*time.Second)
 
 	expected := statusTracker{
 		status: "stopped",
@@ -289,7 +288,7 @@ func TestSaverCantCreate(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	s.start(ctx, 100*time.Millisecond)
+	s.start(ctx, 50*time.Millisecond, 100*time.Millisecond)
 
 	expected := statusTracker{
 		status: "stopped",
@@ -312,7 +311,7 @@ func TestSaverWithRealv4Data(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	s := StartNew(ctx, anonymize.New(anonymize.Netblock), dir, 10*time.Second)
+	s := StartNew(ctx, anonymize.New(anonymize.Netblock), dir, 5*time.Second, 10*time.Second)
 
 	tstamp := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
 	s.UUIDchan <- UUIDEvent{"testUUID", tstamp}
@@ -389,7 +388,7 @@ func TestSaverWithRealv6Data(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	s := StartNew(ctx, anonymize.New(anonymize.Netblock), dir, 10*time.Second)
+	s := StartNew(ctx, anonymize.New(anonymize.Netblock), dir, 5*time.Second, 10*time.Second)
 
 	tstamp := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
 	s.UUIDchan <- UUIDEvent{"testUUID", tstamp}


### PR DESCRIPTION
This change alters the savePackets logic by splitting the read/save loop into two parts:

* Buffer for up to 5 seconds (UUIDDelay), then look for the UUID
* If the UUID is not found, return immediately
* If the UUID is found, continue the read/save loop for the full `duration`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/26)
<!-- Reviewable:end -->
