### PR TITLE
Add a BPF filter and turn off promiscuous mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+before_install:
+- echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+- sudo service docker restart
+
 install:
 - sudo apt-get update && sudo apt-get install -y libpcap-dev
 - go get -v -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 
+# From https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
 before_install:
 - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
 - sudo service docker restart

--- a/main.go
+++ b/main.go
@@ -73,11 +73,11 @@ func processFlags() error {
 	}
 
 	// Special case for argument "-interface": if no specific interface was
-	// specified, then "all of them" was implicitly specified. If new interfaces
-	// are created after capture is started, traffic on those interfaces will be
-	// ignored. If interfaces disappear, the effects are unknown. The number of
-	// interfaces with a running capture is tracked in the
-	// pcap_muxer_interfaces_with_captures metric.
+	// explicitly specified, then "all of them" was implicitly specified. If new
+	// interfaces are created after capture is started, traffic on those
+	// interfaces will be ignored. If interfaces disappear, the effects are
+	// unknown. The number of interfaces with a running capture is tracked in
+	// the pcap_muxer_interfaces_with_captures metric.
 	if len(interfaces) == 0 {
 		log.Println("No interfaces specified, will listen for packets on all available interfaces.")
 		ifaces, err := netInterfaces()

--- a/main.go
+++ b/main.go
@@ -65,10 +65,10 @@ func catch(sig os.Signal) {
 
 var netInterfaces = net.Interfaces
 
-func processFlags() error {
+func processFlags() ([]net.Interface, error) {
 	// Verify that capture duration is always longer than uuid wait duration.
 	if *uuidWaitDuration > *captureDuration {
-		return fmt.Errorf("Capture duration must be greater than UUID wait duration: %s vs %s",
+		return nil, fmt.Errorf("Capture duration must be greater than UUID wait duration: %s vs %s",
 			*captureDuration, *uuidWaitDuration)
 	}
 
@@ -80,15 +80,17 @@ func processFlags() error {
 	// the pcap_muxer_interfaces_with_captures metric.
 	if len(interfaces) == 0 {
 		log.Println("No interfaces specified, will listen for packets on all available interfaces.")
-		ifaces, err := netInterfaces()
-		if err != nil {
-			return fmt.Errorf("Could not list interfaces: %s", err)
-		}
-		for _, iface := range ifaces {
-			interfaces = append(interfaces, iface.Name)
-		}
+		return netInterfaces()
 	}
-	return nil
+	ifaces := []net.Interface{}
+	for _, iface := range interfaces {
+		i, err := net.InterfaceByName(iface)
+		if err != nil {
+			return ifaces, err
+		}
+		ifaces = append(ifaces, *i)
+	}
+	return ifaces, nil
 }
 
 func main() {
@@ -96,7 +98,8 @@ func main() {
 
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
-	rtx.Must(processFlags(), "Failed to process flags")
+	ifaces, err := processFlags()
+	rtx.Must(err, "Failed to process flags")
 
 	psrv := prometheusx.MustServeMetrics()
 	defer warnonerror.Close(psrv, "Could not stop metric server")
@@ -132,7 +135,7 @@ func main() {
 	// Capture packets on every interface.
 	cleanupWG.Add(1)
 	go func() {
-		muxer.MustCaptureTCPOnInterfaces(mainCtx, interfaces, packets, pcapOpenLive, int32(*maxHeaderSize))
+		muxer.MustCaptureTCPOnInterfaces(mainCtx, ifaces, packets, pcapOpenLive, int32(*maxHeaderSize))
 		mainCancel()
 		cleanupWG.Done()
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -30,11 +30,24 @@ func TestProcessFlags(t *testing.T) {
 	defer func() {
 		// Reset function pointer.
 		netInterfaces = net.Interfaces
+		interfaces = flagx.StringArray{}
 	}()
 
 	_, err := processFlags()
 	if err == nil {
 		t.Fatalf("processFlags() return wrong error; got nil, want %q", err)
+	}
+
+	interfaces = flagx.StringArray{"lo"}
+	ifaces, err := processFlags()
+	if err != nil || len(ifaces) != 1 {
+		t.Fatalf("processFlags() did not get the loopback: %s, %+v", err, ifaces)
+	}
+
+	interfaces = flagx.StringArray{"doesnotexist"}
+	_, err = processFlags()
+	if err == nil {
+		t.Fatalf("processFlags() return wrong error; got nil")
 	}
 
 	// Artificially set uuid wait duration to be longer than capture duration.

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestProcessFlags(t *testing.T) {
 		netInterfaces = net.Interfaces
 	}()
 
-	err := processFlags()
+	_, err := processFlags()
 	if err == nil {
 		t.Fatalf("processFlags() return wrong error; got nil, want %q", err)
 	}
@@ -43,7 +43,7 @@ func TestProcessFlags(t *testing.T) {
 		*uuidWaitDuration = *captureDuration / 2
 	}()
 
-	err = processFlags()
+	_, err = processFlags()
 	if err == nil {
 		t.Fatalf("processFlags() return wrong error; got nil, want %q", err)
 	}

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -96,7 +96,7 @@ func MustCaptureTCPOnInterfaces(ctx context.Context, interfaces []net.Interface,
 	log.Printf("Using BPF filter %q\n", filter)
 	for _, iface := range interfaces {
 		// Open a packet capture
-		handle, err := pcapOpenLive(iface.Name, maxHeaderSize, true, pcap.BlockForever)
+		handle, err := pcapOpenLive(iface.Name, maxHeaderSize, false, pcap.BlockForever)
 		rtx.Must(err, "Could not create libpcap client for %q", iface)
 		rtx.Must(handle.SetBPFFilter(filter), "Could not set up BPF filter for TCP")
 

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -95,7 +95,7 @@ func MustCaptureTCPOnInterfaces(ctx context.Context, interfaces []net.Interface,
 	filter := mustMakeFilter(interfaces)
 	log.Printf("Using BPF filter %q\n", filter)
 	for _, iface := range interfaces {
-		// Open a packet capture
+		// Open a packet capture. "false" means promiscuous mode is off.
 		handle, err := pcapOpenLive(iface.Name, maxHeaderSize, false, pcap.BlockForever)
 		rtx.Must(err, "Could not create libpcap client for %q", iface)
 		rtx.Must(handle.SetBPFFilter(filter), "Could not set up BPF filter for TCP")

--- a/muxer/interfaces.go
+++ b/muxer/interfaces.go
@@ -5,6 +5,9 @@ package muxer
 
 import (
 	"context"
+	"log"
+	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +16,16 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/packet-headers/metrics"
+)
+
+// PcapHandleOpener is a type to allow injection of fake packet captures to aid
+// in testing. It is exactly the type of pcap.OpenLive, and in production code
+// every variable of this type should be set to pcap.OpenLive.
+type PcapHandleOpener func(device string, snaplen int32, promisc bool, timeout time.Duration) (handle *pcap.Handle, _ error)
+
+// Injected functions to support whitebox testing.
+var (
+	netInterfaceByName = net.InterfaceByName
 )
 
 func forwardPackets(ctx context.Context, in <-chan gopacket.Packet, out chan<- gopacket.Packet, wg *sync.WaitGroup) {
@@ -45,22 +58,49 @@ func muxPackets(ctx context.Context, in []<-chan gopacket.Packet, out chan<- gop
 	close(out)
 }
 
-// PcapHandleOpener is a type to allow injection of fake packet captures to aid
-// in testing. It is exactly the type of pcap.OpenLive, and in production code
-// every variable of this type should be set to pcap.OpenLive.
-type PcapHandleOpener func(device string, snaplen int32, promisc bool, timeout time.Duration) (handle *pcap.Handle, _ error)
+func mustMakeFilter(interfaces []string) string {
+	filters := []string{}
+	for _, ifName := range interfaces {
+		iface, err := netInterfaceByName(ifName)
+		rtx.Must(err, "Could not get named interface %s", ifName)
+		if iface == nil || iface.Flags&net.FlagLoopback != 0 {
+			// Skip nil interfaces and loopback addresses
+			continue
+		}
+		addrs, err := iface.Addrs()
+		rtx.Must(err, "Could not get addresses for interface %s", ifName)
+		for _, addr := range addrs {
+			a := addr.String()
+			if strings.Contains(a, "/") {
+				a = strings.Split(a, "/")[0]
+			}
+			if strings.Contains(a, ":") {
+				filters = append(filters, "ip6 host "+a)
+			} else {
+				filters = append(filters, "ip host "+a)
+			}
+		}
+	}
+	if len(filters) == 0 {
+		return "tcp"
+	}
+	return "tcp and ( " + strings.Join(filters, " or ") + ")"
+}
 
 // MustCaptureTCPOnInterfaces fires off a packet capture on every one of the
 // passed-in list of interfaces, and then muxes the resulting packet streams to
 // all be sent to the passed-in packets channel.
-func MustCaptureTCPOnInterfaces(ctx context.Context, interfaces []string, packets chan<- gopacket.Packet, opener PcapHandleOpener, maxHeaderSize int32) {
+func MustCaptureTCPOnInterfaces(ctx context.Context, interfaces []string, packets chan<- gopacket.Packet, pcapOpenLive PcapHandleOpener, maxHeaderSize int32) {
 	// Capture packets on every interface.
 	packetCaptures := make([]<-chan gopacket.Packet, 0)
+	// Only capture packets destined for a non-localhost local IP.
+	filter := mustMakeFilter(interfaces)
+	log.Printf("Using BPF filter %q\n", filter)
 	for _, iface := range interfaces {
 		// Open a packet capture
-		handle, err := opener(iface, maxHeaderSize, true, pcap.BlockForever)
+		handle, err := pcapOpenLive(iface, maxHeaderSize, true, pcap.BlockForever)
 		rtx.Must(err, "Could not create libpcap client for %q", iface)
-		rtx.Must(handle.SetBPFFilter("tcp"), "Could not set up BPF filter for TCP")
+		rtx.Must(handle.SetBPFFilter(filter), "Could not set up BPF filter for TCP")
 
 		// Stop packet capture when this function exits.
 		defer handle.Close()

--- a/muxer/interfaces_test.go
+++ b/muxer/interfaces_test.go
@@ -83,22 +83,21 @@ func TestMuxPacketsUntilContextCancellation(t *testing.T) {
 }
 
 func TestMustMakeFilter(t *testing.T) {
-	f := mustMakeFilter([]string{"lo"})
+	lo, err := net.InterfaceByName("lo")
+	rtx.Must(err, "Could not get loopback interface")
+	f := mustMakeFilter([]net.Interface{*lo})
 	if f != "tcp" {
 		t.Error("loopback resulted in non-empty filter")
 	}
-	f = mustMakeFilter([]string{})
+	f = mustMakeFilter([]net.Interface{})
 	if f != "tcp" {
 		t.Error("empty interface list resulted in non-empty filter")
 	}
-	ifaces, err := net.Interfaces()
-	ifNames := []string{}
-	for _, iface := range ifaces {
-		ifNames = append(ifNames, iface.Name)
-	}
 
+	// Now check all the interfaces on the local host, just as a sanity check.
+	ifaces, err := net.Interfaces()
 	rtx.Must(err, "Could not get interface list")
-	f = mustMakeFilter(ifNames)
+	f = mustMakeFilter(ifaces)
 	if f == "" {
 		t.Error("Non-empty interface list resulted in empty filter")
 	}
@@ -125,7 +124,7 @@ func TestMustCaptureOnInterfaces(t *testing.T) {
 	go func() {
 		MustCaptureTCPOnInterfaces(
 			context.Background(),
-			[]string{"../testdata/v4.pcap", "../testdata/v6.pcap"},
+			[]net.Interface{{Name: "../testdata/v4.pcap"}, {Name: "../testdata/v6.pcap"}},
 			packets,
 			fakePcapOpenLive,
 			0,


### PR DESCRIPTION
Should prevent the host context from being forwarded many many packets that it does not care about.

Part of #20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/27)
<!-- Reviewable:end -->
