### PR TITLE
Ensure all IPv4 addresses use only 4 bytes.

### DIFF
--- a/demuxer/flowkey.go
+++ b/demuxer/flowkey.go
@@ -40,7 +40,11 @@ func fromPacket(p gopacket.Packet) FlowKey {
 	return FlowKeyFrom4Tuple(ip1, ip1P, ip2, ip2P)
 }
 
-// FlowKeyFrom4Tuple creates a FlowKey (suitable for use as a map key) from a TCP 4-tuple.
+// FlowKeyFrom4Tuple creates a FlowKey (suitable for use as a map key) from a
+// TCP 4-tuple. IPv4 addresses passed in must be 4 bytes, because we do
+// byte-based comparisons with sub-slices of packets retrieved from the wire,
+// and this function needs to be fast, because it is called for every packet, so
+// we do not do that normalization inside this function.
 func FlowKeyFrom4Tuple(srcIP net.IP, srcPort uint16, dstIP net.IP, dstPort uint16) FlowKey {
 	srcIPS := string(srcIP)
 	dstIPS := string(dstIP)

--- a/demuxer/flowkey.go
+++ b/demuxer/flowkey.go
@@ -41,10 +41,12 @@ func fromPacket(p gopacket.Packet) FlowKey {
 }
 
 // FlowKeyFrom4Tuple creates a FlowKey (suitable for use as a map key) from a
-// TCP 4-tuple. IPv4 addresses passed in must be 4 bytes, because we do
-// byte-based comparisons with sub-slices of packets retrieved from the wire,
-// and this function needs to be fast, because it is called for every packet, so
-// we do not do that normalization inside this function.
+// TCP 4-tuple. This function is called once per packet, by the demuxer, and
+// once per flow, by the tcpeventsocket handler. Because it is called once per
+// packet, it should be as efficient as possible.
+//
+// IPv4 addresses passed in must be 4 bytes, because we do byte-based
+// comparisons with sub-slices of packets retrieved from the wire.
 func FlowKeyFrom4Tuple(srcIP net.IP, srcPort uint16, dstIP net.IP, dstPort uint16) FlowKey {
 	srcIPS := string(srcIP)
 	dstIPS := string(dstIP)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	dir              = flag.String("datadir", ".", "The directory to which data is written")
-	eventSocket      = flag.String("eventsocket", "", "The absolute pathname of the unix-domain socket to which events will be posted.")
 	captureDuration  = flag.Duration("captureduration", 30*time.Second, "Only save the first captureduration of each flow, to prevent long-lived flows from spamming the hard drive.")
 	uuidWaitDuration = flag.Duration("uuidwaitduration", 5*time.Second, "Wait up to uuidwaitduration for each flow before either assigning a UUID or discarding all future packets. This prevents buffering unsaveable packets.")
 	flowTimeout      = flag.Duration("flowtimeout", 30*time.Second, "Once there have been no packets for a flow for at least flowtimeout, the flow can be assumed to be closed.")
@@ -45,6 +44,7 @@ var (
 
 func init() {
 	flag.Var(&interfaces, "interface", "The interface on which to capture traffic. May be repeated. If unset, will capture on all available interfaces.")
+	log.SetFlags(log.Lshortfile | log.LstdFlags)
 }
 
 func catch(sig os.Signal) {
@@ -124,7 +124,7 @@ func main() {
 	h := tcpinfohandler.New(mainCtx, tcpdm.UUIDChan)
 	cleanupWG.Add(1)
 	go func() {
-		eventsocket.MustRun(mainCtx, *eventSocket, h)
+		eventsocket.MustRun(mainCtx, *eventsocket.Filename, h)
 		mainCancel()
 		cleanupWG.Done()
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -76,13 +76,13 @@ func TestMainSmokeTest(t *testing.T) {
 	// server.
 	tcpiCtx, tcpiCancel := context.WithCancel(context.Background())
 	defer tcpiCancel()
-	*eventSocket = dir + "/tcpevents.sock"
-	tcpi := eventsocket.New(*eventSocket)
+	*eventsocket.Filename = dir + "/tcpevents.sock"
+	tcpi := eventsocket.New(*eventsocket.Filename)
 	tcpi.Listen()
 	go tcpi.Serve(tcpiCtx)
 
 	// Wait until the eventsocket appears.
-	for _, err := os.Stat(*eventSocket); err != nil; _, err = os.Stat(*eventSocket) {
+	for _, err := os.Stat(*eventsocket.Filename); err != nil; _, err = os.Stat(*eventsocket.Filename) {
 	}
 
 	// Tests are unlikely to have enough privileges to open packet captures, so

--- a/tcpinfohandler/handler.go
+++ b/tcpinfohandler/handler.go
@@ -39,6 +39,12 @@ func (h *handler) Open(ctx context.Context, timestamp time.Time, uuid string, id
 		metrics.BadEventsFromTCPInfo.WithLabelValues("badip").Inc()
 		return
 	}
+	if srcIP.To4() != nil {
+		srcIP = srcIP.To4()
+	}
+	if dstIP.To4() != nil {
+		dstIP = dstIP.To4()
+	}
 	// Can't use a struct literal here due to embedding.
 	ev := demuxer.UUIDEvent{}
 	ev.Flow = demuxer.FlowKeyFrom4Tuple(srcIP, id.SPort, dstIP, id.DPort)

--- a/tcpinfohandler/handler.go
+++ b/tcpinfohandler/handler.go
@@ -39,6 +39,8 @@ func (h *handler) Open(ctx context.Context, timestamp time.Time, uuid string, id
 		metrics.BadEventsFromTCPInfo.WithLabelValues("badip").Inc()
 		return
 	}
+	// Convert all IPv4 addresses to a 4-byte representation, as required by
+	// FlowKeyFrom4Tuple.
 	if srcIP.To4() != nil {
 		srcIP = srcIP.To4()
 	}


### PR DESCRIPTION
Also, convert the `-eventsocket` flag to the one provided in `tcpinfo.eventsocket`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/30)
<!-- Reviewable:end -->
