### PR TITLE
Add a new state after uuidwait and before dircreation

### DIFF
--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -223,6 +223,7 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	}
 	// uuidEvent is now set to a good value.
 
+	t.state.Set("readingpackets-withuuid")
 	// Continue reading packets until duration has elapsed.
 	for {
 		p, ok := t.readPacket(derivedCtx)

--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -151,7 +151,7 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	// Write PCAP data to the buffer.
 	w := pcapgo.NewWriterNanos(zip)
 	// Now save packets until the stream is done or the context is canceled.
-	t.state.Set("readingpackets")
+	t.state.Set("readingcandidatepackets")
 	// Read the first packet to determine the TCP+IP header size (as IPv6 is variable in size)
 	p, ok := t.readPacket(derivedCtx)
 	if !ok {
@@ -223,7 +223,7 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	}
 	// uuidEvent is now set to a good value.
 
-	t.state.Set("readingpackets-withuuid")
+	t.state.Set("readingsavedpackets")
 	// Continue reading packets until duration has elapsed.
 	for {
 		p, ok := t.readPacket(derivedCtx)

--- a/saver/tcp_test.go
+++ b/saver/tcp_test.go
@@ -158,7 +158,7 @@ func TestSaverWithUUID(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "dircreation", "savingfile", "discardingpackets"},
+		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "savingfile", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -254,7 +254,7 @@ func TestSaverCantMkdir(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "dircreation", "mkdirerror", "discardingpackets"},
+		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "mkdirerror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -292,7 +292,7 @@ func TestSaverCantCreate(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "dircreation", "savingfile", "filewriteerror", "discardingpackets"},
+		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "savingfile", "filewriteerror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)

--- a/saver/tcp_test.go
+++ b/saver/tcp_test.go
@@ -95,9 +95,9 @@ func TestSaverDryRun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// Wait until the status is readingpackets or the surrounding context has been cancelled.
+	// Wait until the status is readingcandidatepackets or the surrounding context has been cancelled.
 	go func() {
-		for s.state.Get() != "readingpackets" && ctx.Err() == nil {
+		for s.state.Get() != "readingcandidatepackets" && ctx.Err() == nil {
 			time.Sleep(1 * time.Millisecond)
 		}
 		cancel()
@@ -106,7 +106,7 @@ func TestSaverDryRun(t *testing.T) {
 	s.start(ctx, 5*time.Second, 10*time.Second) // Give the disk IO 10 seconds to happen.
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "nopacketserror", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "nopacketserror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -158,7 +158,7 @@ func TestSaverWithUUID(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "savingfile", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "uuidwait", "readingsavedpackets", "dircreation", "savingfile", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -189,7 +189,7 @@ func TestSaverNoUUID(t *testing.T) {
 	s.start(ctx, 5*time.Second, 10*time.Second)
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "uuiderror", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "uuidwait", "uuiderror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -220,7 +220,7 @@ func TestSaverNoUUIDClosedUUIDChan(t *testing.T) {
 	s.start(context.Background(), 5*time.Second, 10*time.Second)
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "uuidchanerror", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "uuidwait", "uuidchanerror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -254,7 +254,7 @@ func TestSaverCantMkdir(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "mkdirerror", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "uuidwait", "readingsavedpackets", "dircreation", "mkdirerror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)
@@ -292,7 +292,7 @@ func TestSaverCantCreate(t *testing.T) {
 
 	expected := statusTracker{
 		status: "stopped",
-		past:   []string{"notstarted", "readingpackets", "uuidwait", "readingpackets-withuuid", "dircreation", "savingfile", "filewriteerror", "discardingpackets"},
+		past:   []string{"notstarted", "readingcandidatepackets", "uuidwait", "readingsavedpackets", "dircreation", "savingfile", "filewriteerror", "discardingpackets"},
 	}
 	if !reflect.DeepEqual(&tracker, &expected) {
 		t.Errorf("%+v != %+v", &tracker, &expected)


### PR DESCRIPTION
Currently the saver state appears to stall at "uuidwait" even though uuid handling occurs immediately. This change adds a new state for "readingpackets-withuuid".

My only reservation is that the new state name is kind of long. Suggestions welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/32)
<!-- Reviewable:end -->
