### PR TITLE
Add flag for streaming.

### DIFF
--- a/demuxer/tcp.go
+++ b/demuxer/tcp.go
@@ -41,6 +41,7 @@ type TCP struct {
 	uuidWaitDuration time.Duration
 	anon             anonymize.IPAnonymizer
 	dataDir          string
+	stream           bool
 }
 
 type status interface {
@@ -65,7 +66,7 @@ func (d *TCP) getSaver(ctx context.Context, flow FlowKey) *saver.TCP {
 		if ok {
 			delete(d.oldFlows, flow)
 		} else {
-			t = saver.StartNew(ctx, d.anon, d.dataDir, d.uuidWaitDuration, d.maxDuration, flow.Format(d.anon))
+			t = saver.StartNew(ctx, d.anon, d.dataDir, d.uuidWaitDuration, d.maxDuration, flow.Format(d.anon), d.stream)
 		}
 		d.currentFlows[flow] = t
 	}
@@ -155,7 +156,7 @@ func (d *TCP) CapturePackets(ctx context.Context, packets <-chan gopacket.Packet
 
 // NewTCP creates a demuxer.TCP, which is the system which chooses which channel
 // to send TCP/IP packets for subsequent saving to a file.
-func NewTCP(anon anonymize.IPAnonymizer, dataDir string, uuidWaitDuration, maxFlowDuration time.Duration) *TCP {
+func NewTCP(anon anonymize.IPAnonymizer, dataDir string, uuidWaitDuration, maxFlowDuration time.Duration, stream bool) *TCP {
 	uuidc := make(chan UUIDEvent, 100)
 	return &TCP{
 		UUIDChan:     uuidc,
@@ -169,5 +170,6 @@ func NewTCP(anon anonymize.IPAnonymizer, dataDir string, uuidWaitDuration, maxFl
 		dataDir:          dataDir,
 		maxDuration:      maxFlowDuration,
 		uuidWaitDuration: uuidWaitDuration,
+		stream:           stream,
 	}
 }

--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -42,7 +42,7 @@ func TestTCPDryRun(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, true)
 
 	// While we have a demuxer created, make sure that the processing path for
 	// packets does not crash when given a nil packet.
@@ -85,7 +85,7 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, true)
 	st := &statusTracker{}
 	tcpdm.status = st
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -253,7 +253,7 @@ func TestUUIDWontBlock(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, true)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	flowTimeout      = flag.Duration("flowtimeout", 30*time.Second, "Once there have been no packets for a flow for at least flowtimeout, the flow can be assumed to be closed.")
 	maxHeaderSize    = flag.Int("maxheadersize", 256, "The maximum size of packet headers allowed. A lower value allows the pcap process to be less wasteful but risks more esoteric IPv6 headers (which can theoretically be up to the full size of the packet but in practice seem to be under 128) getting truncated.")
 	sigtermWaitTime  = flag.Duration("sigtermwait", 1*time.Second, "How long should the daemon hang around before exiting after receiving a SIGTERM.")
+	streamToDisk     = flag.Bool("stream", false, "Stream results to disk instead of buffering them in RAM.")
 
 	interfaces flagx.StringArray
 
@@ -118,7 +119,7 @@ func main() {
 	}()
 
 	// Get ready to save the incoming packets to files.
-	tcpdm := demuxer.NewTCP(anonymize.New(anonymize.IPAnonymizationFlag), *dir, *uuidWaitDuration, *captureDuration)
+	tcpdm := demuxer.NewTCP(anonymize.New(anonymize.IPAnonymizationFlag), *dir, *uuidWaitDuration, *captureDuration, *streamToDisk)
 
 	// Inform the demuxer of new UUIDs
 	h := tcpinfohandler.New(mainCtx, tcpdm.UUIDChan)

--- a/saver/export_test.go
+++ b/saver/export_test.go
@@ -15,8 +15,8 @@ var (
 	AnonymizePacket      = anonymizePacket
 )
 
-func NewTCPWithTrackerForTest(dir string, anon anonymize.IPAnonymizer, id string, fs afero.Fs, ss statusSetter) *TCP {
-	tcp := newTCP(dir, anon, id, fs)
+func NewTCPWithTrackerForTest(dir string, anon anonymize.IPAnonymizer, id string, fs afero.Fs, ss statusSetter, stream bool) *TCP {
+	tcp := newTCP(dir, anon, id, fs, stream)
 	tcp.state = ss
 	return tcp
 }


### PR DESCRIPTION
Puts streaming (or not streaming) under control of a command-line flag.  This should allow us to easily test which configuration works best.  Once we have decided which works best in practice, we should make that option the default and then remove the flag.

(Please do not review until #35 is merged, at which point I will rebase this PR on master)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/37)
<!-- Reviewable:end -->
