### PR TITLE
The read-UUID loop is now guaranteed to execute at least once

### DIFF
--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -239,32 +239,44 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 	t.savePacket(w, p, headerLen)
 
 	t.state.Set("uuidwait")
-	// Read packets while waiting for uuid event, or uuidCtx expires..
-	// The error conditions below are expected to occur in production. In
-	// particular, every flow that existed prior to the start of the start of
-	// the packet-headers binary will cause this error at least once.
+	// Read packets while waiting for uuid event, or until uuidCtx expires. The
+	// "uuidtimeout" error conditions below are expected to occur in production
+	// in at least 3 normal conditions:
 	//
-	// This error will also occur for long-lived flows that send packets so
-	// infrequently that the flow gets garbage-collected between packet
-	// arrivals.
-	uuidCtx, uuidCancel := context.WithTimeout(ctx, uuidDelay)
+	// (1) each flow that existed prior to the start of the packet-headers
+	// binary will cause this error at least once,
+	//
+	// (2) long-lived flows that send packets so infrequently that the flow gets
+	// garbage-collected between packet arrivals will cause this error at least
+	// once per garbage-collection round,
+	//
+	// (3) flows that send a SYN but never complete a 3-way handshake will wake
+	// up the TCP saver infrastructure because it looks like a flow was about to
+	// be created, but then the kernel never actually creates the flow.
+	//
+	// Condition 3 is a little bit worrying, as we want an infrastructure that
+	// is not too vulnerable to a SYN flood.
+	// TODO(https://github.com/m-lab/packet-headers/issues/42)
+	uuidCtx, uuidCancel := context.WithTimeout(packetCtx, uuidDelay)
 	defer uuidCancel()
 	var uuidEvent UUIDEvent
-	for first := true; first || uuidCtx.Err() == nil; first = false {
+uuidloop:
+	for {
 		select {
-		// If the context expires, no need to keep capturing.
+		// If the context expires, return. No progress is possible.
 		case <-uuidCtx.Done():
 			log.Println("Context expired waiting for UUID for flow", t.id)
 			t.error("uuidtimedout")
 			return
 
-		// Any packets should be written to the buffer.
+		// Any packets received while waiting for a UUID should be written to
+		// the buffer.
 		case p, ok := <-t.pchanRead:
 			if ok {
 				t.savePacket(w, p, headerLen)
 			}
 
-		// Note: if packet channel gets backed up, select algorithm may drain more packets after UUID arrives.
+		// Once the UUID arrives, exit the loop.
 		case uuidEvent, ok = <-t.uuidchanRead:
 			if !ok {
 				// If the channel is closed, then we can never get the uuid, so stop capturing.
@@ -272,9 +284,10 @@ func (t *TCP) savePackets(ctx context.Context, uuidDelay, duration time.Duration
 				t.error("uuidchanclosed")
 				return
 			}
-			// Once the uuid event is received we cancel the context and exit the loop.
+			// This is the expected common case.
 			t.state.Set("uuidfound")
-			uuidCancel() // Exit the loop
+			// break from the select statement and the surrounding loop.
+			break uuidloop
 		}
 	}
 


### PR DESCRIPTION
Also, the use of contexts has been cleaned up and clarified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/41)
<!-- Reviewable:end -->
