### PR TITLE
Flag -maxheap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
- - 1.18
+ - 1.19
 
 # From https://github.com/travis-ci/travis-ci/issues/8891#issuecomment-353403729
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build packet-headers
-FROM golang:1.18-alpine3.16 as build
+FROM golang:1.19-alpine3.16 as build
 RUN apk --no-cache add libpcap-dev git gcc libc-dev
 COPY . /go/src/github.com/m-lab/packet-headers
 WORKDIR /go/src/github.com/m-lab/packet-headers

--- a/demuxer/tcp.go
+++ b/demuxer/tcp.go
@@ -84,12 +84,12 @@ func (d *TCP) getSaver(ctx context.Context, flow FlowKey) *saver.TCP {
 			// threshold. This condition is required because a SYN flood can
 			// cause packet-headers to allocate memory faster than partial
 			// connection timeouts allow the garbage collector to recover used
-			// memory. The result in that case would be RAM exhaustion.
+			// memory. The result in that case would be system RAM exhaustion.
 			//
 			// NOTE: When we are above the maxHeap threshold, we may lose some
 			// legitimate measurements. This check is a load shedding strategy
 			// to keep the process running and prevent resource usage from
-			// packet-headers to spill over into other components.
+			// packet-headers spilling over into other parts of the system.
 			if currentHeapAboveThreshold(d.maxHeap) {
 				metrics.SaversSkipped.Inc()
 				return nil

--- a/demuxer/tcp.go
+++ b/demuxer/tcp.go
@@ -64,7 +64,6 @@ func (promStatus) GC(stillPresent, discarded int) {
 func currentHeapAboveThreshold(maxHeap uint64) bool {
 	ms := runtime.MemStats{}
 	runtime.ReadMemStats(&ms)
-	// log.Println(ms.HeapAlloc, ">", maxHeap, "==", ms.HeapAlloc > maxHeap)
 	return (ms.HeapAlloc > maxHeap)
 }
 

--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -42,7 +42,7 @@ func TestTCPDryRun(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, 1000000)
 
 	// While we have a demuxer created, make sure that the processing path for
 	// packets does not crash when given a nil packet.
@@ -85,7 +85,7 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, 1000000)
 	st := &statusTracker{}
 	tcpdm.status = st
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -253,7 +253,7 @@ func TestUUIDWontBlock(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true, 1000000)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	var wg sync.WaitGroup

--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/go/bytecount"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 
@@ -42,7 +44,7 @@ func TestTCPDryRun(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, 1000000)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte))
 
 	// While we have a demuxer created, make sure that the processing path for
 	// packets does not crash when given a nil packet.
@@ -85,7 +87,7 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, 1000000)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte))
 	st := &statusTracker{}
 	tcpdm.status = st
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -253,7 +255,7 @@ func TestUUIDWontBlock(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true, 1000000)
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true, uint64(2*bytecount.Gigabyte))
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -112,7 +112,10 @@ func main() {
 
 	rtx.Must(os.Chdir(*dir), "Could not cd to directory %q", *dir)
 
-	// Set a memory limit for the GC to never exceed the maxHeap bytes.
+	// Set a memory limit for the GC to keep RAM used below maxHeap bytes. This
+	// is a soft limit that will alter how the GC behaves (e.g. reclaiming more
+	// frequently, releasing RAM back to the OS) but will not stop RAM usage by
+	// the process.
 	debug.SetMemoryLimit(int64(maxHeap))
 
 	// A waitgroup to make sure main() doesn't return before all its components

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -55,6 +55,12 @@ var (
 		},
 		[]string{"state"},
 	)
+	SaversSkipped = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pcap_saver_skipped_total",
+			Help: "How many flows were never saved due to configured memory limits.",
+		},
+	)
 
 	// Demuxer metrics keep track of the state of the system that sends packets
 	// to a particular saver.


### PR DESCRIPTION
This change adds a new flag (`-maxheap`) to packet-headers that limits the total RAM used by the process. This change requires a new feature of go1.19 [`debug.SetMemoryLimit`][1].

From local testing, in response to a SYN flood event:
* `SetMemoryLimit` alone is not sufficient to prevent eventual RAM exhaustion. New savers are created faster than the timeout and GC removes them.
* Conditional creation of `saver.StartNew` alone is not sufficient to prevent RAM exhaustion either because the GC does not activate frequently enough.

Shorter settings for `-uuidwaittimeout` (down to 100ms) had no effect on the eventual RAM exhaustion.

When total RAM used is greater than `maxHeap`, new streams will be ignored. In effect, this both limits new memory allocations and may prevent some legitimate traces from ever being collected, or collected incompletely.

Collection will resume after adequate RAM is available. The setting for `-maxheap` should be greater or equal to `-maxidleram`.

[1]: https://pkg.go.dev/runtime/debug#SetMemoryLimit

Resolves:
* https://github.com/m-lab/ops-tracker/issues/1682

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/46)
<!-- Reviewable:end -->
