### PR TITLE
Create data dir if it doesn't exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,11 @@ func main() {
 	ifaces, err := processFlags()
 	rtx.Must(err, "Failed to process flags")
 
+	// Create the data directory. This will be a no-op if it already exists.
+	if *dir != "" {
+		rtx.PanicOnError(os.MkdirAll(*dir, 0775), "Could not create the data dir %s", *dir)
+	}
+
 	psrv := prometheusx.MustServeMetrics()
 	defer warnonerror.Close(psrv, "Could not stop metric server")
 


### PR DESCRIPTION
Pusher used to handled creating data directories if they didn't already exist. We removed that functionality from Pusher because it seems more appropriate for the producer of a datatype to create its own data directory. However, we found that pcap did not do this. This commit should cause pcap to create its own data directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/50)
<!-- Reviewable:end -->
