### PR TITLE
Sets cap_net_raw capability on packet-headers binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN chmod a+rx /go/bin/packet-headers
 
 # Put it in its own image.
 FROM alpine:3.16
-RUN apk --no-cache add libpcap
+RUN apk --no-cache add libpcap libcap
 COPY --from=build /go/bin/packet-headers /packet-headers
+RUN setcap cap_net_raw=ep /packet-headers
 WORKDIR /
 ENTRYPOINT ["/packet-headers"]


### PR DESCRIPTION
This allows the pod to run as a non-root user with no additional special capabilities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/51)
<!-- Reviewable:end -->
