### PR TITLE
Filter interfaces that are up

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,10 @@ func processFlags() ([]net.Interface, error) {
 		if err != nil {
 			return ifaces, err
 		}
-		ifaces = append(ifaces, *i)
+		if i.Flags&net.FlagUp != 0 {
+			// We can only capture packets from interfaces that are up.
+			ifaces = append(ifaces, *i)
+		}
 	}
 	return ifaces, nil
 }


### PR DESCRIPTION
This change adds a filter so that the interfaces used are actually administratively "up". This is necessary because packets cannot be collected from down interfaces. For example:

```
iterfaces.go:100: Could not create libpcap client for {'\x02' 'ל' "eno1" "3c:ec:ef:ce:f7:8e" "broadcast|multicast"} (error: eno1: That device is not up)
```

Part of:
* https://github.com/m-lab/ops-tracker/issues/1798

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/52)
<!-- Reviewable:end -->
