### PR TITLE
Write PCAP header after we received a valid UUID

### DIFF
--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -295,6 +295,13 @@ uuidloop:
 	}
 
 	// uuidEvent is now set to a good value.
+	// Write the header and all the packets we have received so far.
+	w.WriteFileHeader(uint32(headerLen), layers.LinkTypeEthernet)
+	for _, earlyPacket := range earlyPackets {
+		t.savePacket(w, earlyPacket, headerLen)
+	}
+	earlyPackets = nil
+
 	// Create a file and directory based on the UUID and the time.
 	t.state.Set("dircreation")
 	dir, fname := filename(t.dir, uuidEvent)
@@ -326,13 +333,6 @@ uuidloop:
 
 		t.state.Set("streaming")
 	}
-
-	// Write the header and all the packets we have received so far.
-	w.WriteFileHeader(uint32(headerLen), layers.LinkTypeEthernet)
-	for _, earlyPacket := range earlyPackets {
-		t.savePacket(w, earlyPacket, headerLen)
-	}
-	earlyPackets = nil
 
 	// Continue reading packets until duration has elapsed.
 	for {


### PR DESCRIPTION
This change moves when the first Write happens, keeping all the packets received before receiving a UUID in a local buffer. 

The difference in terms of used memory is significant (~50% less with 5000 flows) and is explained by the fact that the first write to a `gzip.Writer` allocates more memory than what's needed for the packets alone.