### PR TITLE
Add a configurable limit to the number of current flows

### DIFF
--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -223,17 +223,6 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	if len(v6) != 8 {
 		t.Errorf("%+v should have length 8 not %d", v6, len(v6))
 	}
-
-	// After all that, also check that writes to an out-of-capacity Pchan will
-	// not block.
-	// sav := tcpdm.getSaver(ctx, flow1)
-	// close(sav.PChan())
-	// close(sav.UUIDChan())
-	// // This new channel assigned to sav.Pchan will never be read, so if a blocking
-	// // write is performed then this goroutine will block.
-	// sav.Pchan = make(chan gopacket.Packet)
-	// tcpdm.savePacket(ctx, flow1packets[0])
-	// If this doesn't block, then success!
 }
 
 func TestUUIDWontBlock(t *testing.T) {

--- a/demuxer/tcp_test.go
+++ b/demuxer/tcp_test.go
@@ -42,7 +42,7 @@ func TestTCPDryRun(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte))
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte), 0)
 
 	// While we have a demuxer created, make sure that the processing path for
 	// packets does not crash when given a nil packet.
@@ -85,7 +85,7 @@ func TestTCPWithRealPcaps(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte))
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 500*time.Millisecond, time.Second, 1000000000, true, uint64(2*bytecount.Gigabyte), 0)
 	st := &statusTracker{}
 	tcpdm.status = st
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -253,7 +253,7 @@ func TestUUIDWontBlock(t *testing.T) {
 	rtx.Must(err, "Could not create directory")
 	defer os.RemoveAll(dir)
 
-	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true, uint64(2*bytecount.Gigabyte))
+	tcpdm := NewTCP(anonymize.New(anonymize.None), dir, 15*time.Second, 30*time.Second, 1, true, uint64(2*bytecount.Gigabyte), 0)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -36,8 +36,10 @@ var (
 	maxHeaderSize    = flag.Int("maxheadersize", 256, "The maximum size of packet headers allowed. A lower value allows the pcap process to be less wasteful but risks more esoteric IPv6 headers (which can theoretically be up to the full size of the packet but in practice seem to be under 128) getting truncated.")
 	sigtermWaitTime  = flag.Duration("sigtermwait", 1*time.Second, "How long should the daemon hang around before exiting after receiving a SIGTERM.")
 	streamToDisk     = flag.Bool("stream", false, "Stream results to disk instead of buffering them in RAM.")
-	maxIdleRAM       = 3 * bytecount.Gigabyte
-	maxHeap          = 8 * bytecount.Gigabyte
+	maxFlows         = flag.Int("maxflows", 0, "The maximum number of concurrent flows allowed. When this threshold is reached, new flows will be ignored.")
+
+	maxIdleRAM = 3 * bytecount.Gigabyte
+	maxHeap    = 8 * bytecount.Gigabyte
 
 	interfaces flagx.StringArray
 
@@ -148,7 +150,7 @@ func main() {
 	// Get ready to save the incoming packets to files.
 	tcpdm := demuxer.NewTCP(
 		anonymize.New(anonymize.IPAnonymizationFlag), *dir, *uuidWaitDuration,
-		*captureDuration, maxIdleRAM, *streamToDisk, uint64(maxHeap))
+		*captureDuration, maxIdleRAM, *streamToDisk, uint64(maxHeap), *maxFlows)
 
 	// Inform the demuxer of new UUIDs
 	h := tcpinfohandler.New(mainCtx, tcpdm.UUIDChan)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -95,6 +95,12 @@ var (
 			Help: "How many savers were still active after the most recent garbage collection round",
 		},
 	)
+	DemuxerIgnoredCount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pcap_demuxer_ignored_total",
+			Help: "How many packets or UUIDs were ignored due to the configured flow limit.",
+		},
+	)
 
 	BadEventsFromTCPInfo = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/saver/tcp.go
+++ b/saver/tcp.go
@@ -169,6 +169,16 @@ type TCP struct {
 	stopOnce sync.Once
 }
 
+// PChan returns the Pchan field.
+func (t *TCP) PChan() chan<- gopacket.Packet {
+	return t.Pchan
+}
+
+// UUIDChan returns the UUIDchan field.
+func (t *TCP) UUIDChan() chan<- UUIDEvent {
+	return t.UUIDchan
+}
+
 // Increment the error counter when errors are encountered.
 func (t *TCP) error(cause string) {
 	t.state.Set(cause + "error")


### PR DESCRIPTION
This PR adds a new `-maxflows` flag that sets the maximum amount of concurrent flows packet-headers will handle.

When the limit is reached, whenever a new flow would be created for an incoming packet, the packet is routed to a "drain" saver that does nothing except for draining the packet and the uuid channels. Since this saver is a singleton and shared across multiple flows, we avoid creating new goroutines and allocating more memory.

Also, the new drain saver is now used when the memory usage goes over the configured threshold. `getSaver` would previously return `nil` and cause an increment of the `pcap_missed_packets_total` metric, which (according to its help text) should always be zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-headers/58)
<!-- Reviewable:end -->
